### PR TITLE
Fix file upload thumbnails on older browsers

### DIFF
--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -114,11 +114,16 @@ export const ImageUploader: React.FC<ImageUploaderProps> = ({ onImagesChange, on
     
     // Create new files with 'queued' status. This is the only thing this function does now.
     // The UI will update instantly showing the previews.
+    const generateId = () =>
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? (crypto as Crypto).randomUUID()
+        : Math.random().toString(36).substring(2, 10);
+
     const newUploadables: UploadableFile[] = files.map(file => ({
       file,
-      id: crypto.randomUUID(),
+      id: generateId(),
       preview: URL.createObjectURL(file), // Important: Creates a temporary local URL for the thumbnail
-      status: 'queued', 
+      status: 'queued',
     }));
 
     setUploadableFiles(prev => [...prev, ...newUploadables]);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -81,7 +81,13 @@ export default {
         }
         
         const s3 = getR2Client(env);
-        const uniqueFilename = `${crypto.randomUUID()}-${filename}`;
+
+        const generateId = () =>
+          typeof crypto !== 'undefined' && 'randomUUID' in crypto
+            ? (crypto as Crypto).randomUUID()
+            : Math.random().toString(36).substring(2, 10);
+
+        const uniqueFilename = `${generateId()}-${filename}`;
 
         const signedUrl = await getSignedUrl(
           s3,


### PR DESCRIPTION
## Summary
- use safe uuid generator for image IDs when browser doesn't support `crypto.randomUUID`
- do the same for worker-generated filenames

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881bbedc0b0833194201c977e314ff5